### PR TITLE
fix #174 simulator version doesn't match

### DIFF
--- a/src/run/iOS.js
+++ b/src/run/iOS.js
@@ -289,10 +289,14 @@ function _runAppOnSimulator({device, xcodeProject, options, resolve, reject}) {
  */
 function simulatorIsAvailable(info, device) {
   info = info.devices
-  simList = info['iOS ' + device.version]
-  for (const sim of simList) {
-    if (sim.udid === device.udid) {
-      return sim.availability === '(available)'
+  for (const key in info) {
+    if (key.indexOf('iOS') > -1) {
+      simList = info[key];
+      for (const sim of simList) {
+        if (sim.udid === device.udid) {
+          return sim.availability === '(available)'
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
`xcrun instruments -s devices` will get version 10.3.1, but `xcrun simctl list --json devices` will get version 10.3.

`simList = info['iOS ' + device.version]` will be undefined
