### PR TITLE
【升级到 ios-deploy 1.9.3】 修正了mac OS系统下的，如下问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "mocha": "^3.2.0"
   },
   "optionalDependencies": {
-    "ios-deploy": "^1.8.6"
+    "ios-deploy": "^1.9.3"
   },
   "changelog": {
     "messages": [


### PR DESCRIPTION
The following build commands failed:
	PhaseScriptExecution Run\ Script build/ios-deploy.build/Release/ios-deploy.build/Script-C0CD3D981F59D20100F954DB.sh