### PR TITLE
update: watch src dir deep, while runAdroid,

### DIFF
--- a/src/run/android.js
+++ b/src/run/android.js
@@ -182,7 +182,7 @@ const registeFileWatcher = (
   chokidar.watch(path.join(rootPath, 'dist'), { ignored: /\w*\.web\.js$/ })
   .on('change', (event) => {
     copyJsbundleAssets(rootPath, 'dist', 'platforms/android/app/src/main/assets/dist', true).then(() => {
-      if (path.basename(event) === configs.WeexBundle) {
+      if (event && event.endsWith(configs.WeexBundle)) {
         logger.info(`Reloading page... \n`);
         ws.send(JSON.stringify({ method: 'WXReloadBundle', params: `http://${configs.ip}:${configs.port}/${configs.WeexBundle}` }));
       }


### PR DESCRIPTION
## Why
When new a page in path './src/business/index.vue' and  'npm run android', it can not hot Reload
Because [path.basename] return only 'index.js', [confis.WeexBundle] is 'business/index.js', The Condition is false.

## So 
change condition to [string].endsWith([string])
